### PR TITLE
install cantera during travis build

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -78,3 +78,6 @@ fi
 
 # go to RMG-tests folder:
 cd $TRAVIS_BUILD_DIR
+
+# install cantera via conda:
+conda install -c bryanwweber cantera -y

--- a/install.sh
+++ b/install.sh
@@ -80,4 +80,4 @@ fi
 cd $TRAVIS_BUILD_DIR
 
 # install cantera via conda:
-conda install -c bryanwweber cantera -y
+conda install -n rmg_env -c bryanwweber cantera -y


### PR DESCRIPTION
is a first step in using cantera simulations to validate generated models by comparing model observables (eg speciation data, ignition delays, etc...-) rather than model details, which is the current state.

cantera is installed via bryan weber's anaconda channel. Currently installs v2.2.1

[Here](https://github.com/Cantera/cantera/issues/261#issuecomment-167114919) it is discussed how cantera can be installed via anaconda.