### PR TITLE
Run observables comparison tests, next to unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,12 @@ script:
   - make ARGS="eg7" run
   - make ARGS="NC" run
   - make ARGS="MCH" run
+  - make ARGS="solvent_hexane" run
 
 after_script:
   - chmod +x after_install.sh
   - . ./after_install.sh
-
+  
 cache:
   pip: true
   apt: true

--- a/check.sh
+++ b/check.sh
@@ -38,3 +38,12 @@ echo 'Memory used, Benchmark:'
 grep "Memory used:" $benchmarkmodel/RMG.log | tail -1
 echo 'Memory used, Tested:'
 grep "Memory used:" $testmodel/RMG.log | tail -1
+
+# regression testing
+regr=examples/rmg/$target/regression_input.py
+if [ -f "$regr" ];
+then
+	python $RMG/rmgpy/tools/regression.py $regr $benchmarkmodel/chemkin $testmodel/chemkin/
+else
+	echo "Regression input file not found. Not running a regression test."
+fi

--- a/examples/rmg/MCH/regression_input.py
+++ b/examples/rmg/MCH/regression_input.py
@@ -1,0 +1,38 @@
+
+options(
+    title = 'MCH',
+    tolerance = 0.05
+)
+
+observable(
+    label='MCH',
+    structure=SMILES("CC1CCCCC1"),
+)
+
+species(
+    label='O2',
+    structure=adjacencyList(
+        """
+        multiplicity 3
+        1 O u1 p2 c0 {2,S}
+        2 O u1 p2 c0 {1,S}
+        """),
+)
+
+species(
+    label='N2',
+    structure=SMILES("N#N"),
+)
+
+# reactor setups
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([100],'s'),
+    initialMoleFractionsList=[{
+        "MCH": 0.01,
+        "O2": 0.105,
+        "N2": 0.885,
+    }],
+    temperatures=([2000],'K'),
+    pressures=([20.],'bar'),
+)

--- a/examples/rmg/NC/regression_input.py
+++ b/examples/rmg/NC/regression_input.py
@@ -1,0 +1,37 @@
+
+options(
+    title = 'NC',
+    tolerance = 0.05
+)
+
+observable(
+    label='NC',
+    structure=SMILES("NC"),
+)
+
+species(
+    label='O2',
+    structure=SMILES("[O][O]"),
+)
+
+species(
+    label='Ar',
+    structure=adjacencyList(
+                """
+                1 Ar u0 p4 c0
+                """),
+)
+
+
+# reactor setups
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([0.002],'s'),
+    initialMoleFractionsList=[{
+        "NC": 0.0005,
+        "O2": 0.002,
+        "Ar": 0.9975,
+    }],
+    temperatures=([1500],'K'),
+    pressures=([2.],'atm'),
+)

--- a/examples/rmg/eg1/regression_input.py
+++ b/examples/rmg/eg1/regression_input.py
@@ -1,0 +1,44 @@
+
+options(
+    title = 'EG1',
+    tolerance = 0.05
+)
+
+# observables
+observable(
+	label = 'ethane',
+    structure=adjacencyList(
+        """
+        1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+		2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+		3 H u0 p0 c0 {1,S}
+		4 H u0 p0 c0 {1,S}
+		5 H u0 p0 c0 {1,S}
+		6 H u0 p0 c0 {2,S}
+		7 H u0 p0 c0 {2,S}
+		8 H u0 p0 c0 {2,S}
+        """),
+)
+
+observable(
+	label = 'methyl',
+    structure=SMILES("[CH3]"),
+)
+
+# species definition used in the reactor setup specification
+species(
+	label = 'argon',
+    structure=SMILES("[Ar]"),
+)
+
+# reactor setups
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([1e3],'s'),
+    initialMoleFractionsList=[{
+        "ethane": .95,
+        "argon": 0.05,
+    }],
+    temperatures=([1350],'K'),
+    pressures=([1.0],'bar'),
+)

--- a/examples/rmg/eg5/regression_input.py
+++ b/examples/rmg/eg5/regression_input.py
@@ -1,0 +1,28 @@
+
+options(
+    title = 'EG5',
+    tolerance = 0.05
+)
+
+observable(
+    label='n-heptane',
+    structure=SMILES("CCCCCCC"),
+)
+
+# species definition used in the reactor setup specification
+species(
+	label = 'Ar',
+    structure=SMILES("[Ar]"),
+)
+
+# reactor setups
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([1e0],'s'),
+    initialMoleFractionsList=[{
+        "n-heptane": 0.02,
+        "Ar": 0.98,
+    }],
+    temperatures=([1500],'K'),
+    pressures=([400.],'Pa'),
+)

--- a/examples/rmg/eg6/regression_input.py
+++ b/examples/rmg/eg6/regression_input.py
@@ -1,0 +1,34 @@
+
+options(
+    title = 'EG6',
+    tolerance = 0.05
+)
+
+observable(
+    label='ethane',
+    structure=SMILES("CC"),
+)
+
+species(
+    label='O2',
+    structure=SMILES("[O][O]"),
+)
+
+# species definition used in the reactor setup specification
+species(
+	label = 'Ar',
+    structure=SMILES("[Ar]"),
+)
+
+# reactor setups
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([1e0],'s'),
+    initialMoleFractionsList=[{
+        "ethane": 1,
+        "O2": 3.5,
+        "Ar": 1,
+    }],
+    temperatures=([1500],'K'),
+    pressures=([2.],'bar'),
+)

--- a/examples/rmg/eg7/regression_input.py
+++ b/examples/rmg/eg7/regression_input.py
@@ -1,0 +1,21 @@
+
+options(
+    title = 'EG7',
+    tolerance = 0.05
+)
+
+observable(
+    label='ethane',
+    structure=SMILES("CC"),
+)
+
+# reactor setups
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([1e-1],'s'),
+    initialMoleFractionsList=[{
+        "ethane": 1.0,
+    }],
+    temperatures=([1350],'K'),
+    pressures=([1.],'bar'),
+)


### PR DESCRIPTION
This PR runs tests that compare observables of reactor simulations, next to detailed model comparisons.

observables can be speciation data at the end time of the reactor simulation. An input file, `regression_input.py` in the `examples` folder explains which observables are compared, under which reactor conditions.

