### PR TITLE
Add longer simulation cases

### DIFF
--- a/examples/rmg/diesel/input.py
+++ b/examples/rmg/diesel/input.py
@@ -1,0 +1,84 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'], 
+    kineticsFamilies = 'default',
+    kineticsEstimator = 'rate rules',
+)
+
+# List of species
+species(
+    label='n-decylbz',
+    reactive=True,
+    structure=SMILES("CCCCCCCCCCc1ccccc1"),
+)
+species(
+    label='n-C11',
+    reactive=True,
+    structure=SMILES("CCCCCCCCCCC"),
+)
+species(
+    label='n-C13',
+    reactive=True,
+    structure=SMILES("CCCCCCCCCCCCC"),
+)
+species(
+    label='n-C16',
+    reactive=True,
+    structure=SMILES("CCCCCCCCCCCCCCCC"),
+)
+species(
+    label='n-C19',
+    reactive=True,
+    structure=SMILES("CCCCCCCCCCCCCCCCCCC"),
+)
+species(
+    label='n-C21',
+    reactive=True,
+    structure=SMILES("CCCCCCCCCCCCCCCCCCCCC"),
+)
+species(
+    label='O2',
+    reactive=True,
+    structure=SMILES("[O][O]"),
+)
+
+# Reaction systems
+simpleReactor(
+    temperature=(500,'K'),
+    pressure=(201.0,'bar'),
+    initialMoleFractions={
+        "n-C11": 0.15,
+        "n-C13": 0.19,
+        "n-C16": 0.25,
+        "n-C19": 0.18,
+        "n-C21": 0.10,
+        "n-decylbz": 0.12,
+        "O2": 0.05,
+    },
+    terminationConversion={
+        'O2': 0.5,
+    },
+    terminationTime=(3600,'s'),
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=0.0001,
+    toleranceMoveToCore=0.01,
+    toleranceInterruptSimulation=0.5,
+    maximumEdgeSpecies=1000
+)
+
+options(
+    units='si',
+    saveRestartPeriod=None,
+    generateOutputHTML=False,
+    generatePlots=False,
+)

--- a/examples/rmg/e85/input.py
+++ b/examples/rmg/e85/input.py
@@ -1,0 +1,91 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary', 'GRI-Mech3.0'],
+    reactionLibraries = [],
+    seedMechanisms = ['GRI-Mech3.0'],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = ['!Intra_Disproportionation','!Substitution_O'],
+    kineticsEstimator = 'rate rules',
+)
+
+# Constraints on generated species
+generatedSpeciesConstraints(
+    allowed=['seed mechanisms'],
+    maximumRadicalElectrons = 2,
+)
+
+# List of species
+species(
+    label='O2',     # oxygen
+    reactive=True,
+    structure=SMILES("[O][O]"),
+)
+species(
+    label='C8H18i', # isooctane
+    reactive=True,
+    structure=SMILES("CC(C)CC(C)(C)C"),
+)
+species(
+    label='C2H6On', # ethanol
+    reactive=True,
+    structure=SMILES("CCO"),
+)
+species(
+    label='C7H8t',  # toluene
+    reactive=True,
+    structure=SMILES("Cc1ccccc1"),
+)
+species(
+    label='C6H12n', # hex-1-ene
+    reactive=True,
+    structure=SMILES("CCCCC=C"),
+)
+species(
+    label='Ar',    # argon
+    reactive=False,
+    structure=SMILES("[Ar]"),
+)
+
+# Reaction systems
+simpleReactor(
+    temperature=(1000,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        "O2": 0.00707000960551,
+        "C8H18i": 6.89999461306e-05,
+        "C2H6On": 0.0018620014036,
+        "C7H8t": 4.80001013417e-05,
+        "C6H12n": 2.1000044337e-05,
+        "Ar": 0.990929988899,
+    },
+    terminationConversion = {'C2H6On': 0.9},
+    terminationTime = (2e2,'s'),
+)
+   
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=0.01,
+    toleranceInterruptSimulation=1.0,
+    maximumEdgeSpecies=1000000,
+)
+
+#pressureDependence(
+#    method='reservoir state',
+#    grainSize=(2.0,'kcal/mol'),
+#    numberOfGrains=200,
+#    temperatures=(300,2000,'K',8),
+#    pressures=(0.01,100,'bar',5),
+#    interpolation=('Chebyshev', 6, 4),
+#)
+
+options(
+    units='si',
+    generateOutputHTML=False,
+    generatePlots=False,
+)
+

--- a/examples/rmg/eg2/input.py
+++ b/examples/rmg/eg2/input.py
@@ -1,0 +1,92 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary', 'GRI-Mech3.0'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'], 
+    kineticsFamilies = 'default',
+    kineticsEstimator = 'rate rules',
+)
+
+# Constraints on generated species
+generatedSpeciesConstraints(
+    maximumRadicalElectrons = 2,
+)
+
+# List of species
+species(
+    label='HXD13',
+    reactive=True,
+    structure=SMILES("C=CC=CCC"),
+)
+species(
+    label='CH4',
+    reactive=True,
+    structure=SMILES("C"),
+)
+species(
+    label='H2',
+    reactive=True,
+    structure=adjacencyList(
+        """
+        1 H u0 p0 {2,S}
+        2 H u0 p0 {1,S}
+        """),
+)
+species(
+    label='N2',
+    reactive=False,
+    structure=InChI("InChI=1/N2/c1-2"),
+)
+
+# Reaction systems
+simpleReactor(
+    temperature=(1350,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        "HXD13": 6.829e-4,
+        "CH4": 0.104,
+        "H2": 0.0156,
+        "N2": 0.8797,
+    },
+    terminationConversion={
+        'HXD13': 0.9,
+    },
+    terminationTime=(1e0,'s'),
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=0.5,
+    toleranceInterruptSimulation=0.5,
+    maximumEdgeSpecies=100000
+)
+
+quantumMechanics(
+    software='mopac',
+    method='pm3',
+    # fileStore='QMfiles', # relative to where it is run. Defaults within the output folder.
+    scratchDirectory = None, # not currently used
+    onlyCyclics = True,
+    maxRadicalNumber = 0,
+    )
+
+pressureDependence(
+    method='modified strong collision',
+    maximumGrainSize=(0.5,'kcal/mol'),
+    minimumNumberOfGrains=250,
+    temperatures=(300,2000,'K',8),
+    pressures=(0.01,100,'bar',5),
+    interpolation=('Chebyshev', 6, 4),
+)
+
+options(
+    units='si',
+    generateOutputHTML=False,
+    generatePlots=False,
+)

--- a/examples/rmg/ethane_sensitivity/input.py
+++ b/examples/rmg/ethane_sensitivity/input.py
@@ -1,0 +1,58 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary'],
+    reactionLibraries = [],
+    seedMechanisms = [],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = ['!Intra_Disproportionation','!Substitution_O'],
+    kineticsEstimator = 'rate rules',
+)
+
+# Constraints on generated species
+generatedSpeciesConstraints(
+    maximumRadicalElectrons = 2,
+)
+
+# List of species
+species(
+    label='ethane',
+    reactive=True,
+    structure=SMILES("CC"),
+)
+
+# Reaction systems
+simpleReactor(
+    temperature=(1350,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        "ethane": 1.0,
+    },
+    terminationConversion={
+        'ethane': 0.9,
+    },
+    terminationTime=(1e6,'s'),
+    sensitivity=['ethane'],
+    sensitivityThreshold=0.01,
+)
+
+simulator(
+    atol=1e-16,
+    rtol=1e-8,
+    sens_atol=1e-6,
+    sens_rtol=1e-4,
+)
+
+model(
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=0.1,
+    toleranceInterruptSimulation=0.1,
+    maximumEdgeSpecies=100000
+)
+
+options(
+    units='si',
+    saveRestartPeriod=None,
+    saveSimulationProfiles=False,
+    generateOutputHTML=False,
+    generatePlots=False,
+)

--- a/examples/rmg/mfmt/input.py
+++ b/examples/rmg/mfmt/input.py
@@ -1,0 +1,150 @@
+# Data sources
+database(
+    thermoLibraries = ['primaryThermoLibrary','DFT_QCI_thermo','GRI-Mech3.0'],
+    reactionLibraries = [('Methylformate',False),('Glarborg/highP',False)],
+    seedMechanisms = ['Glarborg/C2'],
+    kineticsDepositories = ['training'],
+    kineticsFamilies = ['!Intra_Disproportionation','!Substitution_O'],
+    kineticsEstimator = 'rate rules',
+)
+
+generatedSpeciesConstraints(
+    allowed = ['seed mechanisms','reaction libraries', 'input species'],
+)
+
+# List of species
+species(
+    label='Mfmt',
+    reactive=True,
+    structure=SMILES("COC=O"),
+)
+species(
+    label='O2',
+    reactive=True,
+    structure=SMILES("[O][O]"),
+)
+species(
+    label='H2O',
+    reactive=True,
+    structure=SMILES("O"),
+)
+species(
+    label='H2',
+    reactive=True,
+    structure=SMILES("[H][H]"),
+)
+species(
+    label='CO',
+    reactive=True,
+    structure=SMILES("[C-]#[O+]"),
+)
+species(
+    label='CO2',
+    reactive=True,
+    structure=SMILES("C(=O)=O"),
+)
+species(
+    label='CH4',
+    reactive=True,
+    structure=SMILES("C"),
+)
+species(
+    label='CH3',
+    reactive=True,
+    structure=SMILES("[CH3]"),
+)
+species(
+    label='CH3OH',
+    reactive=True,
+    structure=SMILES("CO"),
+)
+species(
+    label='C2H4',
+    reactive=True,
+    structure=SMILES("C=C"),
+)
+species(
+    label='C2H2',
+    reactive=True,
+    structure=SMILES("C#C"),
+)
+species(
+    label='CH2O',
+    reactive=True,
+    structure=SMILES("C=O"),
+)
+species(
+    label='CH3CHO',
+    reactive=True,
+    structure=SMILES("CC=O"),
+)
+
+
+# Bath gas
+species(
+    label='Ar',
+    reactive=False,
+    structure=InChI("InChI=1S/Ar"),
+)
+
+# Reaction systems
+simpleReactor(
+    temperature=(650,'K'),
+    pressure=(1.0,'bar'),
+    initialMoleFractions={
+        "Mfmt": 0.01,
+        "O2": 0.02,
+        "Ar": 0.08,
+    },
+    terminationTime=(0.5,'s'),
+)
+simpleReactor(
+    temperature=(1350,'K'),
+    pressure=(3.0,'bar'),
+    initialMoleFractions={
+        "Mfmt": 0.01,
+        "O2": 0.02,
+        "Ar": 0.97,
+    },
+    terminationTime=(0.5,'s'),
+)
+simpleReactor(
+    temperature=(1950,'K'),
+    pressure=(10.0,'bar'),
+    initialMoleFractions={
+        "Mfmt": 0.01,
+        "O2": 0.02,
+        "Ar": 0.97,
+    },
+    terminationTime=(0.5,'s'),
+)
+
+simulator(
+    atol=1e-22,
+    rtol=1e-8,
+)
+
+model(
+    toleranceKeepInEdge=0.0,
+    toleranceMoveToCore=0.0005,
+    toleranceInterruptSimulation=1.0,
+    maximumEdgeSpecies=100000
+)
+
+pressureDependence(
+    method='modified strong collision', # 'reservoir state'
+    maximumGrainSize=(1.0,'kcal/mol'),
+    minimumNumberOfGrains=200,
+    temperatures=(290,3500,'K',8),
+    pressures=(0.02,100,'bar',5),
+    interpolation=('Chebyshev', 6, 4),
+    maximumAtoms=16,
+)
+
+options(
+    units='si',
+    generateOutputHTML=False,
+    generatePlots=False,
+    saveSimulationProfiles=False,
+    saveEdgeSpecies=True,
+)


### PR DESCRIPTION
These 4 cases will run much longer than any previous ones, and should preferably not be run in the context of continuous integration.

They could instead be used to monitor resource usage and performance characteristics.