### PR TITLE
Fix NC test example

### DIFF
--- a/examples/rmg/NC/input.py
+++ b/examples/rmg/NC/input.py
@@ -58,7 +58,7 @@ options(
     units='si',
     generateOutputHTML=False,
     generatePlots=False,
-    saveEdgeSpecies=False,
+    saveEdgeSpecies=True,
     saveSimulationProfiles=False,
 	saveRestartPeriod=None,
 )

--- a/examples/rmg/NC/regression_input.py
+++ b/examples/rmg/NC/regression_input.py
@@ -1,0 +1,37 @@
+
+options(
+    title = 'NC',
+    tolerance = 0.05
+)
+
+observable(
+    label='NC',
+    structure=SMILES("NC"),
+)
+
+species(
+    label='O2',
+    structure=SMILES("[O][O]"),
+)
+
+species(
+    label='Ar',
+    structure=adjacencyList(
+                """
+                1 Ar u0 p4 c0
+                """),
+)
+
+
+# reactor setups
+reactorSetups(
+    reactorTypes=['IdealGasReactor'],
+    terminationTimes=([0.002],'s'),
+    initialMoleFractionsList=[{
+        "NC": 0.0005,
+        "O2": 0.002,
+        "Ar": 0.9975,
+    }],
+    temperatures=([1500],'K'),
+    pressures=([2.],'atm'),
+)


### PR DESCRIPTION
This PR tries to

- add regression test back for NC which was disabled before for static benchmark reason

- saves edge for NC so that RMG-tests can compare edge between benchmark and testing versions 