### PR TITLE
detect OS from MACHTYPE instead of user input

### DIFF
--- a/local_tests/exe.sh
+++ b/local_tests/exe.sh
@@ -3,6 +3,17 @@
 export BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 echo "Local tests base dir: "$BASE_DIR
 
+# Figure out OS
+if [[ $MACHTYPE == *"apple"* ]]; then
+	export CURRENT_OS="mac"
+elif [[ $MACHTYPE == *"linux"* ]]; then
+	export CURRENT_OS="linux"
+else
+	echo "$MACHTYPE not supported. Exiting..."
+	exit 0
+fi
+echo "Current OS: "$CURRENT_OS
+
 . $BASE_DIR/local_tests/input.sh
 . $BASE_DIR/color_define.sh
 . $BASE_DIR/install.sh

--- a/local_tests/input.sh
+++ b/local_tests/input.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-export CURRENT_OS="mac" # only supports "mac" and "linux"
 export RMG_TESTING_BRANCH="master"
 export RMGDB_TESTING_BRANCH="master"
 export JOBS="NC"


### PR DESCRIPTION
In order to reduce user input, the OS info can be extracted directly from MACHTYPE.