### PR TITLE
Provide example slurm submission scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Normally RMG-tests run automatically all the examples registered in `examples` f
 	cd local_tests
 	bash exe.sh
 	```
-If you are running on a server, create a submission script with this code in it. 
+If you are running on a server, we've provided two example submission scripts (serial and parallel). 
+For serial mode of testing:
+	```bash
+	sbatch submit_serial.sl
+	``` 
+For parallel mode of testing:
+	```bash
+	sbatch submit_parallel.sl $(pwd)
+	```
 
 5. You'll find the test log in folder `RMG-tests/tests/check/${you job name}`, and two versions of RMG-generated CHEMKIN models in folder `RMG-tests/tests/benchmark/${you job name}` and `RMG-tests/tests/testmodel/${you job name}` for detailed analysis.

--- a/local_tests/run.sl
+++ b/local_tests/run.sl
@@ -1,0 +1,9 @@
+#!/bin/bash
+#SBATCH -p debug
+#SBATCH -J run
+#SBATCH -n 1
+
+JOB=$1
+SCOOP=$2
+
+bash $BASE_DIR/run.sh $JOB $SCOOP

--- a/local_tests/submit_parallel.sl
+++ b/local_tests/submit_parallel.sl
@@ -1,0 +1,38 @@
+#!/bin/bash
+#SBATCH -p debug
+#SBATCH -J submit
+#SBATCH -n 1
+
+# usage: sbatch submit_parallel.sl $(pwd)
+
+export BASE_DIR="$( cd $1/../ && pwd)"
+echo "Local tests base dir: "$BASE_DIR
+
+# Figure out OS
+if [[ $MACHTYPE == *"apple"* ]]; then
+	export CURRENT_OS="mac"
+elif [[ $MACHTYPE == *"linux"* ]]; then
+	export CURRENT_OS="linux"
+else
+	echo "$MACHTYPE not supported. Exiting..."
+	exit 0
+fi
+echo "Current OS: "$CURRENT_OS
+
+. $BASE_DIR/local_tests/input.sh
+. $BASE_DIR/color_define.sh
+. $BASE_DIR/install.sh
+. $BASE_DIR/version_summary.sh
+
+if [ $JOBS == "all" ]; then
+	for i in eg1 eg3 eg5 eg6 eg7 NC solvent_hexane no
+	do
+		sbatch $BASE_DIR/local_tests/run.sl $i no
+	done
+
+	sbatch $BASE_DIR/local_tests/run.sl MCH yes
+else
+	sbatch $BASE_DIR/local_tests/run.sl $JOBS no
+fi
+
+. $BASE_DIR/local_tests/clean_up.sh

--- a/local_tests/submit_serial.sl
+++ b/local_tests/submit_serial.sl
@@ -1,0 +1,6 @@
+#!/bin/bash
+#SBATCH -p debug
+#SBATCH -J submit
+#SBATCH -n 1
+
+bash exe.sh

--- a/version_summary.sh
+++ b/version_summary.sh
@@ -22,4 +22,4 @@ cd $RMGDB_TESTING
 git log --format=%H%n%cd -1
 echo "========================================="
 
-cd $TRAVIS_BUILD_DIR
+cd $BASE_DIR


### PR DESCRIPTION
This PR adds two submission scripts for slurm scheduler system.

## Serial mode of testing on slurm server:
after modify `input.sh`, run
```bash
sbatch submit_serial.sl
```

## Parallel mode of testing on slurm server:
after modify `input.sh`, run
```bash
sbatch submit_parallel.sl $(pwd)
```