### PR TITLE
Removed setting the rmgrc file for benchmark and test builds

### DIFF
--- a/local_tests/clean_up.sh
+++ b/local_tests/clean_up.sh
@@ -2,5 +2,3 @@
 
 conda remove -n benchmark --all -y
 conda remove -n testing --all -y 
-
-rm -rf $HOME/.rmg

--- a/run.sh
+++ b/run.sh
@@ -23,12 +23,6 @@ source activate benchmark
 echo "benchmark version of RMG: "$RMG_BENCHMARK
 export PYTHONPATH=$RMG_BENCHMARK:$ORIGIN_PYTHONPATH 
 
-# use the rmgrc file to point to the location of the desired RMG-database:
-rmgrc="database.directory : "${RMGDB_BENCHMARK}/input/
-rm -rf $HOME/.rmg
-mkdir -p $HOME/.rmg
-echo $rmgrc >> $HOME/.rmg/rmgrc
-
 python $RMG_BENCHMARK/rmg.py $BASE_DIR/tests/benchmark/$eg/input.py > /dev/null
 
 source deactivate
@@ -46,16 +40,9 @@ echo "test version of RMG: "$RMG_TESTING
 
 export PYTHONPATH=$RMG_TESTING:$ORIGIN_PYTHONPATH 
 
-# use the rmgrc file to point to the location of the desired RMG-database:
-rmgrc="database.directory : "${RMGDB_TESTING}/input/
-rm -rf $HOME/.rmg
-mkdir -p $HOME/.rmg
-echo $rmgrc >> $HOME/.rmg/rmgrc
-
 python $RMG_TESTING/rmg.py $BASE_DIR/tests/testmodel/$eg/input.py > /dev/null
 export PYTHONPATH=$ORIGIN_PYTHONPATH
 source deactivate
-
 
 # compare both generated models
 mkdir -p $BASE_DIR/tests/check/$eg


### PR DESCRIPTION
Previously the rmgrc file which directs RMG-Py to the appropriate location of RMG-database was stored in /HOME/.rmg/.rmgrc. This is dangerous because if a local run of RMG-tests does not complete, the rmgrc will still build to either the benchmark or test version of RMG-database, possibly without the user's knowledge. Afterwards, the user may run RMG and unintentionally use the wrong pathway to RMG-database.

It was found that RMG-Py will default to looking for RMG-database relative to its own position if nothing is provided. Because the local run of RMG-tests naturally sets up RMG-database this way for both bechmark and test builds, it is not necessary to ever set the rmgrc.