### PR TITLE
Change KlippensteinH2O2 to new BurkeH2O2inN library for MCH example

### DIFF
--- a/examples/rmg/MCH/input.py
+++ b/examples/rmg/MCH/input.py
@@ -1,7 +1,7 @@
 # Data sources
 database(
     thermoLibraries = ['KlippensteinH2O2', 'primaryThermoLibrary','DFT_QCI_thermo','CBS_QB3_1dHR'],
-    reactionLibraries = [('KlippensteinH2O2', False), ('combustion_core/version5', False)],
+    reactionLibraries = [('BurkeH2O2inN2', False), ('combustion_core/version5', False)],
     seedMechanisms = [],
     kineticsDepositories = ['training'],
     kineticsFamilies = 'default',


### PR DESCRIPTION
Previously the MCH example used a rxn library that is now deprecated. This changes it to the new location of the the equivalent library. 