### PR TITLE
add nitrogen constraint for methane example

### DIFF
--- a/examples/rmg/methane/input.py
+++ b/examples/rmg/methane/input.py
@@ -2,7 +2,7 @@
 database(
     thermoLibraries = ['primaryThermoLibrary'],
     reactionLibraries = [], #['GRI-Mech3.0-N'],
-    seedMechanisms = ['GRI-Mech3.0'],
+    seedMechanisms = ['GRI-Mech3.0-N'],
     kineticsDepositories = ['training'],
     kineticsFamilies = 'default',
     kineticsEstimator = 'rate rules',

--- a/examples/rmg/methane/input.py
+++ b/examples/rmg/methane/input.py
@@ -65,5 +65,6 @@ options(
 
 generatedSpeciesConstraints(
     #allows exceptions to the following restrictions
-    allowed=['seed mechanisms']
+    allowed=['seed mechanisms'],
+    maximumNitrogenAtoms=2
 )


### PR DESCRIPTION
This PR modifies the methane example so that nitrogen polymer won't be generated see #55 