### PR TITLE
New data test

### DIFF
--- a/examples/thermo_val/n_cyclics/dataset.txt
+++ b/examples/thermo_val/n_cyclics/dataset.txt
@@ -1,0 +1,2 @@
+
+rmg.sdata134k.N_cyclic_table

--- a/examples/thermo_val/rmg_internal_hetero/dataset.txt
+++ b/examples/thermo_val/rmg_internal_hetero/dataset.txt
@@ -1,0 +1,4 @@
+
+rmg.rmg_internal.rg_sulfur_195_table
+rmg.rmg_internal.agd_nitrogen_6_table
+rmg.rmg_internal.rmg_cl_table

--- a/local_tests/exe.sh
+++ b/local_tests/exe.sh
@@ -51,6 +51,7 @@ fi
 . $BASE_DIR/local_tests/thermo_val.sh hco_cyclics
 . $BASE_DIR/local_tests/thermo_val.sh n_cyclics
 . $BASE_DIR/local_tests/thermo_val.sh rmg_internal_cyclics
+. $BASE_DIR/local_tests/thermo_val.sh rmg_internal_hetero
 
 . $BASE_DIR/local_tests/clean_up.sh
 

--- a/local_tests/exe.sh
+++ b/local_tests/exe.sh
@@ -49,6 +49,7 @@ fi
 
 . $BASE_DIR/local_tests/thermo_val.sh hc_cyclics
 . $BASE_DIR/local_tests/thermo_val.sh hco_cyclics
+. $BASE_DIR/local_tests/thermo_val.sh n_cyclics
 . $BASE_DIR/local_tests/thermo_val.sh rmg_internal_cyclics
 
 . $BASE_DIR/local_tests/clean_up.sh


### PR DESCRIPTION
This PR adds more datasets for thermo regression testing. mainly added three datasets

- N_cyclic_table: from 134k

- agd_nitrogen_6_table: from Alon's calculations

- rg_sulfur_195_table: from Ryan's calculations

- rmg_cl_table: from Zach's database `chlorine` PR

Can be pulled in after RMG-Py `chargedAT` and `chlorine` is merged.