### PR TITLE
Updated name for generate_resonance_isomers

### DIFF
--- a/thermo_val/model.py
+++ b/thermo_val/model.py
@@ -25,7 +25,7 @@ class ThermoEstimator(object):
 
         if self.kernel_type == 'GA':
             spec = Species().fromSMILES(smiles)
-            spec.generateResonanceIsomers()
+            spec.generate_resonance_isomers()
 
             thermo = self.kernel.getThermoDataFromGroups(spec)
 


### PR DESCRIPTION
generate_resonance_isomers used to be called generateResonanceIsomers.
This commit fixes the name of the method on RMG-tests