### PR TITLE
Corrected method name

### DIFF
--- a/thermo_val/model.py
+++ b/thermo_val/model.py
@@ -25,7 +25,7 @@ class ThermoEstimator(object):
 
         if self.kernel_type == 'GA':
             spec = Species().fromSMILES(smiles)
-            spec.generate_resonance_isomers()
+            spec.generate_resonance_structures()
 
             thermo = self.kernel.getThermoDataFromGroups(spec)
 


### PR DESCRIPTION
The previous commit used generate_resonance_isomers.
The current name is generate_resonance_structures, which
this commit changes it to.