### PR TITLE
Skip the (slow) installation before running the finish stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ jobs:
     - script:
         - ./run.sh examples/eg1 no
     - stage: finish
+      install: skip
       script: skip
       after_success:
         - . ./after_success.sh


### PR DESCRIPTION
The installation step takes 20 minutes, and I don't think is needed to run the final cleanup script
to signal success.