### PR TITLE
Fix path to MOPAC executable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -126,11 +126,11 @@ conda deactivate
 
 # setup MOPAC for both environments
 conda activate $BENCHMARK_CONDA_ENV
-yes 'Yes' | $BASE_DIR/miniconda/envs/benchmark/bin/mopac $MOPACKEY > /dev/null
+yes 'Yes' | $BENCHMARK_CONDA_ENV/bin/mopac $MOPACKEY > /dev/null
 conda deactivate
 
 conda activate $TESTING_CONDA_ENV
-yes 'Yes' | $BASE_DIR/miniconda/envs/testing/bin/mopac $MOPACKEY > /dev/null
+yes 'Yes' | $TESTING_CONDA_ENV/bin/mopac $MOPACKEY > /dev/null
 conda deactivate
 
 


### PR DESCRIPTION
The Superminimal regression test fails because the MOPAC license wasn't properly installed in the install.sh script.

The error given from [this](https://pipelines.actions.githubusercontent.com/c9MOlUpqlxk17onyPH01JTuKKNTQPQin1AX5Ki4pfsARtlUM7K/_apis/pipelines/1/runs/84/signedlogcontent/2?urlExpires=2021-11-16T15%3A25%3A05.6115362Z&urlSigningMethod=HMACV1&urlSignature=RtePjl%2BWvdjjbzHnUFx695ngXLuURMBPdQGmPEIfwU8%3D) Github Actions log file:
```
yes 'Yes' | $BASE_DIR/miniconda/envs/benchmark/bin/mopac $MOPACKEY > /dev/null
./install.sh: line 129: /home/runner/work/RMG-tests/RMG-tests/miniconda/envs/benchmark/bin/mopac: No such file or directory
```

It looks like this was just because the path to the mopac bin file was wrong. The base folder should be 
`/usr/share/miniconda/envs/benchmark` instead of ` /home/runner/work/RMG-tests/RMG-tests/miniconda/envs/benchmark`

Hopefully this commit fixes the error. Check the [Github Actions log](https://github.com/ReactionMechanismGenerator/RMG-tests/actions/runs/1467625234) in two hours to see if that worked.