### PR TITLE
Don't exit if benchmark job timed out

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -39,7 +39,6 @@ then
   echo "Benchmark job completed"
 else
   echo "Benchmark job timed out"
-  exit 1
 fi
 
 conda deactivate


### PR DESCRIPTION
Sometimes the main branch fails and a PR intends to fix it. It's useful to not exit when the benchmark job failed and proceed to the testing job.